### PR TITLE
Handle missing filenames

### DIFF
--- a/internal/app/squealer/scan/git_scanner.go
+++ b/internal/app/squealer/scan/git_scanner.go
@@ -219,7 +219,12 @@ func (s *gitScanner) processFile(cf CommitFile) error {
 		return err
 	}
 
-	err = s.mc.Evaluate(cf.changePath, content, cf.commit)
+	filepath := cf.changePath
+	if filepath == "" {
+		filepath = cf.file.Name
+	}
+
+	err = s.mc.Evaluate(filepath, content, cf.commit)
 	s.metrics.IncrementFilesProcessed()
 	return err
 }


### PR DESCRIPTION
If the filename is missing, then use the Name from the file attribute.
Still want to prefer the change path for more detail