### PR TITLE
refactor: return pointer instead of value in getScanner

### DIFF
--- a/internal/app/squealer/cmd/root.go
+++ b/internal/app/squealer/cmd/root.go
@@ -76,7 +76,7 @@ func squeal(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func getScanner(cfg *config.Config, basePath string) (squealer.Scanner, error) {
+func getScanner(cfg *config.Config, basePath string) (*squealer.Scanner, error) {
 	scanner, err := squealer.New(
 		squealer.OptionWithConfig(cfg),
 		squealer.OptionRedactedSecrets(redacted),
@@ -87,7 +87,7 @@ func getScanner(cfg *config.Config, basePath string) (squealer.Scanner, error) {
 		squealer.OptionWithScanEverything(everything),
 		squealer.OptionWithCommitListFile(commitListFile),
 	)
-	return *scanner, err
+	return scanner, err
 }
 
 func printMetrics(metrics *metrics.Metrics) string {


### PR DESCRIPTION
If `squealer.New` returns an error, dereferencing a pointer will cause a panic.